### PR TITLE
MultiTypeahead should use a SortedCollector instead of SimpleCollector

### DIFF
--- a/src/main/java/cleo/search/typeahead/MultiTypeahead.java
+++ b/src/main/java/cleo/search/typeahead/MultiTypeahead.java
@@ -33,7 +33,7 @@ import cleo.search.Element;
 import cleo.search.collector.Collector;
 import cleo.search.collector.MultiCollector;
 import cleo.search.collector.MultiSourceCollector;
-import cleo.search.collector.SimpleCollector;
+import cleo.search.collector.SortedCollector;
 import cleo.search.util.Strings;
 
 /**
@@ -88,7 +88,7 @@ public class MultiTypeahead<E extends Element> implements Typeahead<E> {
   
   @Override
   public List<E> search(int uid, String[] terms, int maxNumResults, long timeoutMillis) {
-    Collector<E> collector = new SimpleCollector<E>(maxNumResults);
+    Collector<E> collector = new SortedCollector<E>(maxNumResults);
     collector = search(uid, terms, collector, timeoutMillis);
     return collector.elements();
   }


### PR DESCRIPTION
Perhaps because I'm combining a set of WeightedNetworkTypeahead instances via a MultiTypeahead, the results returned when using e.g. maxResults=10 didn't match the top 10 results shown when returning all results. This was because MultiTypeahead used a SimpleCollector and simply stopped collecting after N results, without using a heap to collect the top N. This commit switches the default collector used by MultiTypeahead to a SortedCollector, which seems to me the more logical choice and fixed my ranking issue.
